### PR TITLE
fix: use asm, truncate progress message when too long, allow configurable logging and publish artifacts

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -91,7 +91,10 @@ jobs:
     name: Cross compile
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -Dwarnings
+      RUSTFLAGS: -Dwarnings -C target-feature=+bmi2,+adx
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-featurez=+bmi2,+adx
+      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-feature=+bmi2,+adx
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-feature=+bmi2,+adx
     strategy:
       matrix:
         rust:
@@ -109,8 +112,6 @@ jobs:
 
       - name: Compile for musl
         run: |
-          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
-          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C target-featurez=+bmi2,+adx"
           sudo apt install musl-tools
           rustup target install x86_64-unknown-linux-musl
           cargo build --bin contribute --release --target x86_64-unknown-linux-musl
@@ -120,8 +121,6 @@ jobs:
 
       - name: Compile for MacOS
         run: |
-          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
-          export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C target-feature=+bmi2,+adx"
           sudo apt install gcc-mingw-w64-x86-64
           rustup target install x86_64-apple-darwin
           git clone https://github.com/tpoechtrager/osxcross
@@ -137,8 +136,6 @@ jobs:
 
       - name: Compile for Windows
         run: |
-          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
-          export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C target-feature=+bmi2,+adx"
           rustup target install x86_64-pc-windows-gnu
           cargo build --bin contribute --release --target x86_64-pc-windows-gnu
           b2sum ./target/x86_64-pc-windows-gnu/release/contribute.exe

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -112,9 +112,9 @@ jobs:
           sudo apt install musl-tools
           rustup target install x86_64-unknown-linux-musl
           cargo build --bin contribute --release --target x86_64-unknown-linux-musl
-          b2sum ./target/x86_64-unknown-linux-musl/contribute
+          b2sum ./target/x86_64-unknown-linux-musl/release/contribute
           cargo build --bin generate --release --target x86_64-unknown-linux-musl
-          b2sum ./target/x86_64-unknown-linux-musl/generate
+          b2sum ./target/x86_64-unknown-linux-musl/release/generate
 
       - name: Compile for MacOS
         run: |
@@ -127,17 +127,17 @@ jobs:
           UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
           cd ..
           PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin contribute --release --target x86_64-apple-darwin
-          b2sum ./target/x86_64-apple-darwin/contribute
+          b2sum ./target/x86_64-apple-darwin/release/contribute
           PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
-          b2sum ./target/x86_64-apple-darwin/generate
+          b2sum ./target/x86_64-apple-darwin/release/generate
 
       - name: Compile for Windows
         run: |
           rustup target install x86_64-pc-windows-gnu
           cargo build --bin contribute --release --target x86_64-pc-windows-gnu
-          b2sum ./target/x86_64-pc-windows-gnu/contribute
+          b2sum ./target/x86_64-pc-windows-gnu/release/contribute.exe
           cargo build --bin generate --release --target x86_64-pc-windows-gnu
-          b2sum ./target/x86_64-pc-windows-gnu/generate
+          b2sum ./target/x86_64-pc-windows-gnu/release/generate.exe
 
       - name: Archive binaries
         uses: actions/upload-artifact@v2

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -128,7 +128,7 @@ jobs:
           cd ..
           PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="$RUSTFLAGS -C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin contribute --release --target x86_64-apple-darwin
           b2sum ./target/x86_64-apple-darwin/release/contribute
-          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS=""$RUSTFLAGS -C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
+          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="$RUSTFLAGS -C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
           b2sum ./target/x86_64-apple-darwin/release/generate
 
       - name: Compile for Windows

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -91,10 +91,7 @@ jobs:
     name: Cross compile
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -Dwarnings -C target-feature=+bmi2,+adx
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+bmi2,+adx
-      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-featurez=+bmi2,+adx
-      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-featurez=+bmi2,+adx
+      RUSTFLAGS: -Dwarnings
     strategy:
       matrix:
         rust:
@@ -129,9 +126,9 @@ jobs:
           mv MacOSX10.10.sdk.tar.xz tarballs/
           UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
           cd ..
-          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin contribute --release --target x86_64-apple-darwin
+          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="$RUSTFLAGS -C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin contribute --release --target x86_64-apple-darwin
           b2sum ./target/x86_64-apple-darwin/release/contribute
-          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
+          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS=""$RUSTFLAGS -C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
           b2sum ./target/x86_64-apple-darwin/release/generate
 
       - name: Compile for Windows

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -91,7 +91,7 @@ jobs:
     name: Cross compile
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -Dwarnings -C target-feature=+bmi2,+adx
+      RUSTFLAGS: -Dwarnings -C target-featurez=+bmi2,+adx
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-featurez=+bmi2,+adx
       CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-feature=+bmi2,+adx
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-feature=+bmi2,+adx

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -92,9 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Dwarnings -C target-featurez=+bmi2,+adx
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-featurez=+bmi2,+adx
-      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-feature=+bmi2,+adx
-      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-feature=+bmi2,+adx
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+bmi2,+adx
+      CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-featurez=+bmi2,+adx
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-featurez=+bmi2,+adx
     strategy:
       matrix:
         rust:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -112,6 +112,9 @@ jobs:
           sudo apt install musl-tools
           rustup target install x86_64-unknown-linux-musl
           cargo build --bin contribute --release --target x86_64-unknown-linux-musl
+          b2sum ./target/x86_64-unknown-linux-musl/contribute
+          cargo build --bin generate --release --target x86_64-unknown-linux-musl
+          b2sum ./target/x86_64-unknown-linux-musl/generate
 
       - name: Compile for MacOS
         run: |
@@ -124,8 +127,20 @@ jobs:
           UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
           cd ..
           PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin contribute --release --target x86_64-apple-darwin
+          b2sum ./target/x86_64-apple-darwin/contribute
+          PATH="$PWD/osxcross/target/bin:$PATH" CC="$PWD/osxcross/target/bin/o64-clang" CXX="$PWD/osxcross/target/bin/o64-clang++" RUSTFLAGS="-C linker=$PWD/osxcross/target/bin/x86_64-apple-darwin14-clang -C ar=$PWD/osxcross/target/bin/x86_64-apple-darwin14-ar" cargo build --bin generate --release --target x86_64-apple-darwin
+          b2sum ./target/x86_64-apple-darwin/generate
 
       - name: Compile for Windows
         run: |
           rustup target install x86_64-pc-windows-gnu
           cargo build --bin contribute --release --target x86_64-pc-windows-gnu
+          b2sum ./target/x86_64-pc-windows-gnu/contribute
+          cargo build --bin generate --release --target x86_64-pc-windows-gnu
+          b2sum ./target/x86_64-pc-windows-gnu/generate
+
+      - name: Archive binaries
+        uses: actions/upload-artifact@v2
+        path: |
+          target/**/contribute
+          target/**/generate

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Archive binaries
         uses: actions/upload-artifact@v2
-        path: |
-          target/**/contribute
-          target/**/generate
+        with:
+          path: |
+            target/**/contribute
+            target/**/generate

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -91,7 +91,7 @@ jobs:
     name: Cross compile
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -Dwarnings -C target-featurez=+bmi2,+adx
+      RUSTFLAGS: -Dwarnings -C target-feature=+bmi2,+adx
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: -C target-feature=+bmi2,+adx
       CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS: -C target-featurez=+bmi2,+adx
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C target-featurez=+bmi2,+adx

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Compile for musl
         run: |
+          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
+          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C target-featurez=+bmi2,+adx"
           sudo apt install musl-tools
           rustup target install x86_64-unknown-linux-musl
           cargo build --bin contribute --release --target x86_64-unknown-linux-musl
@@ -118,6 +120,8 @@ jobs:
 
       - name: Compile for MacOS
         run: |
+          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
+          export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C target-feature=+bmi2,+adx"
           sudo apt install gcc-mingw-w64-x86-64
           rustup target install x86_64-apple-darwin
           git clone https://github.com/tpoechtrager/osxcross
@@ -133,6 +137,8 @@ jobs:
 
       - name: Compile for Windows
         run: |
+          export RUSTFLAGS="-C target-feature=+bmi2,+adx"
+          export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C target-feature=+bmi2,+adx"
           rustup target install x86_64-pc-windows-gnu
           cargo build --bin contribute --release --target x86_64-pc-windows-gnu
           b2sum ./target/x86_64-pc-windows-gnu/release/contribute.exe
@@ -143,5 +149,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: |
-            target/**/contribute
-            target/**/generate
+            target/**/contribute*
+            target/**/generate*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "num-traits",
  "paste",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "flate2",
  "futures-core",
  "memchr",
@@ -224,7 +224,7 @@ dependencies = [
  "log",
  "native-tls",
  "pin-project",
- "tokio 0.2.22",
+ "tokio",
  "tokio-native-tls",
  "tungstenite",
 ]
@@ -243,7 +243,7 @@ dependencies = [
  "RustyXML",
  "async-trait",
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes",
  "chrono",
  "failure",
  "futures",
@@ -269,7 +269,7 @@ dependencies = [
  "RustyXML",
  "azure_core",
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes",
  "chrono",
  "failure",
  "futures",
@@ -466,12 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
-
-[[package]]
 name = "c2-chacha"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,15 +525,6 @@ name = "closure"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6173fd61b610d15a7566dd7b7620775627441c4ab9dac8906e17cb93a24b782"
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "console"
@@ -1043,7 +1028,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-native-tls",
  "url",
 ]
@@ -1249,7 +1234,7 @@ checksum = "759bfe7464299589f02197a973e0e01f17c4cdcef87b454579af8b0629ba7420"
 dependencies = [
  "futures",
  "pin-project",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1378,7 +1363,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1386,7 +1371,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
@@ -1448,7 +1433,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1459,7 +1444,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "http",
 ]
 
@@ -1481,7 +1466,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1493,7 +1478,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2",
- "tokio 0.2.22",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1505,14 +1490,14 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.22",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1523,10 +1508,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "hyper",
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -1596,16 +1581,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.6",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
-dependencies = [
- "cfg-if 1.0.0",
+ "bytes",
 ]
 
 [[package]]
@@ -1708,15 +1684,6 @@ name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
-
-[[package]]
-name = "lock_api"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1831,16 +1798,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.5"
+name = "mio-named-pipes"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "libc",
  "log",
+ "mio",
  "miow 0.3.5",
- "ntapi",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
 ]
 
 [[package]]
@@ -2073,32 +2050,6 @@ dependencies = [
  "bitvec 0.17.4",
  "byte-slice-cast",
  "serde",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2517,7 +2468,7 @@ checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "async-compression",
  "base64 0.12.3",
- "bytes 0.5.6",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2539,7 +2490,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio",
  "tokio-rustls",
  "tokio-tls",
  "url",
@@ -2998,7 +2949,7 @@ dependencies = [
  "setup-utils",
  "sysinfo",
  "thiserror",
- "tokio 0.3.3",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3298,33 +3249,17 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
- "memchr",
- "mio 0.6.22",
- "num_cpus",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
-dependencies = [
- "autocfg",
- "bytes 0.6.0",
- "futures-core",
- "lazy_static",
  "libc",
  "memchr",
- "mio 0.7.5",
+ "mio",
+ "mio-named-pipes",
+ "mio-uds",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -3334,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.1"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3350,7 +3285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -3361,7 +3296,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.22",
+ "tokio",
  "webpki",
 ]
 
@@ -3372,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -3381,12 +3316,12 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -3505,7 +3440,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes 0.5.6",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "num-traits",
  "paste",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "flate2",
  "futures-core",
  "memchr",
@@ -224,7 +224,7 @@ dependencies = [
  "log",
  "native-tls",
  "pin-project",
- "tokio",
+ "tokio 0.2.22",
  "tokio-native-tls",
  "tungstenite",
 ]
@@ -243,7 +243,7 @@ dependencies = [
  "RustyXML",
  "async-trait",
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "failure",
  "futures",
@@ -269,7 +269,7 @@ dependencies = [
  "RustyXML",
  "azure_core",
  "base64 0.13.0",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "failure",
  "futures",
@@ -466,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +531,15 @@ name = "closure"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6173fd61b610d15a7566dd7b7620775627441c4ab9dac8906e17cb93a24b782"
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "console"
@@ -1028,7 +1043,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-native-tls",
  "url",
 ]
@@ -1234,7 +1249,7 @@ checksum = "759bfe7464299589f02197a973e0e01f17c4cdcef87b454579af8b0629ba7420"
 dependencies = [
  "futures",
  "pin-project",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1363,7 +1378,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1371,7 +1386,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
 ]
@@ -1433,7 +1448,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1444,7 +1459,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1466,7 +1481,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1478,7 +1493,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1490,14 +1505,14 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "webpki",
 ]
@@ -1508,10 +1523,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
 ]
 
@@ -1581,7 +1596,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1684,6 +1708,15 @@ name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1798,26 +1831,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
+name = "mio"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
 dependencies = [
- "log",
- "mio",
- "miow 0.3.5",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
  "libc",
- "mio",
+ "log",
+ "miow 0.3.5",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2050,6 +2073,32 @@ dependencies = [
  "bitvec 0.17.4",
  "byte-slice-cast",
  "serde",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2468,7 +2517,7 @@ checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "async-compression",
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2490,7 +2539,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "tokio-tls",
  "url",
@@ -2933,11 +2982,13 @@ dependencies = [
  "hex",
  "indicatif",
  "lazy_static",
+ "num_cpus",
  "openssl-sys",
  "panic-control",
  "phase1",
  "phase1-cli",
  "rand 0.7.3",
+ "rayon",
  "reqwest",
  "retry",
  "rpassword",
@@ -2947,7 +2998,7 @@ dependencies = [
  "setup-utils",
  "sysinfo",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3247,17 +3298,33 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
+ "memchr",
+ "mio 0.6.22",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg",
+ "bytes 0.6.0",
+ "futures-core",
+ "lazy_static",
  "libc",
  "memchr",
- "mio",
- "mio-named-pipes",
- "mio-uds",
+ "mio 0.7.5",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -3267,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3283,7 +3350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3294,7 +3361,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "webpki",
 ]
 
@@ -3305,7 +3372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3314,12 +3381,12 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3438,7 +3505,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 dependencies = [
  "accel",
  "algebra-core",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "algebra-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 dependencies = [
  "accel",
  "algebra-core-derive",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -333,7 +333,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 [[package]]
 name = "bench-utils"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 
 [[package]]
 name = "bincode"
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 dependencies = [
  "algebra-core",
  "rand 0.7.3",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
+source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
 dependencies = [
  "algebra-core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 dependencies = [
  "accel",
  "algebra-core",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "algebra-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 dependencies = [
  "accel",
  "algebra-core-derive",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -333,7 +333,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 [[package]]
 name = "bench-utils"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 
 [[package]]
 name = "bincode"
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 dependencies = [
  "algebra-core",
  "rand 0.7.3",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=02cd4d60a2dbbd5cc69abeea9010610d704f1b34#02cd4d60a2dbbd5cc69abeea9010610d704f1b34"
+source = "git+https://github.com/celo-org/zexe?rev=181ac2f05dde303f2f295a676c18a3343e6ef22c#181ac2f05dde303f2f295a676c18a3343e6ef22c"
 dependencies = [
  "algebra-core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
 
 [[package]]
+name = "accel"
+version = "0.4.0-alpha.0"
+source = "git+https://github.com/jon-chuang/accel#cd83208b07b3e3cf269ec06437a69e062e0f8d86"
+dependencies = [
+ "accel-derive",
+ "bitflags",
+ "cuda-driver-sys",
+ "derive-new",
+ "futures",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "accel-derive"
+version = "0.3.0"
+source = "git+https://github.com/jon-chuang/accel#cd83208b07b3e3cf269ec06437a69e062e0f8d86"
+dependencies = [
+ "anyhow",
+ "dirs 2.0.2",
+ "failure",
+ "maplit",
+ "proc-macro-crate",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "serde",
+ "syn 1.0.44",
+ "toml",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,7 +78,7 @@ dependencies = [
  "chacha20poly1305",
  "console",
  "cookie-factory",
- "dirs",
+ "dirs 3.0.1",
  "hkdf",
  "hmac 0.9.0",
  "nom",
@@ -77,34 +113,43 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 dependencies = [
+ "accel",
  "algebra-core",
+ "lazy_static",
+ "paste",
 ]
 
 [[package]]
 name = "algebra-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 dependencies = [
+ "accel",
  "algebra-core-derive",
  "cc",
+ "closure",
  "derivative",
+ "dirs 1.0.5",
  "either",
  "itertools 0.9.0",
+ "lazy_static",
+ "log",
  "num-traits",
  "paste",
+ "peekmore",
  "rand 0.7.3",
  "rayon",
  "rustc_version",
+ "serde_json",
  "unroll",
- "voracious_radix_sort",
 ]
 
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -288,7 +333,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 [[package]]
 name = "bench-utils"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 
 [[package]]
 name = "bincode"
@@ -474,6 +519,12 @@ dependencies = [
  "time 0.1.44",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "closure"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6173fd61b610d15a7566dd7b7620775627441c4ab9dac8906e17cb93a24b782"
 
 [[package]]
 name = "console"
@@ -675,6 +726,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.44",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +794,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -985,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 dependencies = [
  "algebra-core",
  "rand 0.7.3",
@@ -1594,6 +1695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.44",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "peekmore"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089f831c514cbf080bd19bfce702f7a2de250492730d419204af6710ba19316"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/celo-org/zexe?rev=ba217a777e8b09b59037a2a3408a0c5812ec65fb#ba217a777e8b09b59037a2a3408a0c5812ec65fb"
+source = "git+https://github.com/celo-org/zexe?rev=7c518fd419c3ebed471314473a4752952162262f#7c518fd419c3ebed471314473a4752952162262f"
 dependencies = [
  "algebra-core",
  "tracing",
@@ -3187,6 +3323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,12 +3577,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "voracious_radix_sort"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c76cba4a47731b29152961b4b6861156b03cdb339683a9cef81d0cc5e53cf"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ setup-utils = { git = "https://github.com/celo-org/snark-setup", package = "setu
 secrecy = { version = "0.7" }
 ctrlc = "3.1.7"
 indicatif = "0.15.0"
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra", default-features = false, features = [ "bw6_761", "bls12_377" ] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "algebra", default-features = false, features = [ "bw6_761", "bls12_377" ] }
 openssl-sys = { version = "0.9", features = ["vendored"]}
 age = { git = "https://github.com/str4d/rage", version = "0.4.0", features = [ "cli-common", "armor" ] }
 bincode = "1.3"
@@ -48,8 +48,8 @@ cuda = [ "zexe_algebra/cuda" ]
 bw6_asm = [ "zexe_algebra/force_bw6_asm" ]
 
 [patch.'https://github.com/scipr-lab/zexe']
-zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra-core", default-features = false, features = ["derive"] }
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "algebra-core", default-features = false, features = ["derive"] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "181ac2f05dde303f2f295a676c18a3343e6ef22c", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", package = "azure_core", default-features = false }
 azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", package = "azure_storage", default-features = false, features = ["blob"] }
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3", features = [ "full" ] }
 byteorder = "1.3.4"
 retry = "1.1.0"
 serde_json = { version = "1.0", features = [ "preserve_order" ] }
@@ -41,6 +41,8 @@ futures-retry = "0.5.0"
 sysinfo = "0.15.3"
 blake2 = "0.9"
 rpassword = "5.0.0"
+rayon = "1.4"
+num_cpus = "1.13"
 
 [features]
 default = [ "bw6_asm" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ setup-utils = { git = "https://github.com/celo-org/snark-setup", package = "setu
 secrecy = { version = "0.7" }
 ctrlc = "3.1.7"
 indicatif = "0.15.0"
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "algebra", default-features = false, features = ["bw6_761", "bls12_377"] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra", default-features = false, features = [ "bw6_761", "bls12_377" ] }
 openssl-sys = { version = "0.9", features = ["vendored"]}
 age = { git = "https://github.com/str4d/rage", version = "0.4.0", features = [ "cli-common", "armor" ] }
 bincode = "1.3"
@@ -42,9 +42,14 @@ sysinfo = "0.15.3"
 blake2 = "0.9"
 rpassword = "5.0.0"
 
+[features]
+default = [ "bw6_asm" ]
+cuda = [ "zexe_algebra/cuda" ]
+bw6_asm = [ "zexe_algebra/bw6_asm" ]
+
 [patch.'https://github.com/scipr-lab/zexe']
-zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "algebra-core", default-features = false, features = ["derive"] }
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "ba217a777e8b09b59037a2a3408a0c5812ec65fb", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra-core", default-features = false, features = ["derive"] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", package = "azure_core", default-features = false }
 azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", package = "azure_storage", default-features = false, features = ["blob"] }
-tokio = { version = "0.3", features = [ "full" ] }
+tokio = { version = "0.2", features = [ "full" ] }
 byteorder = "1.3.4"
 retry = "1.1.0"
 serde_json = { version = "1.0", features = [ "preserve_order" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ setup-utils = { git = "https://github.com/celo-org/snark-setup", package = "setu
 secrecy = { version = "0.7" }
 ctrlc = "3.1.7"
 indicatif = "0.15.0"
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra", default-features = false, features = [ "bw6_761", "bls12_377" ] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra", default-features = false, features = [ "bw6_761", "bls12_377" ] }
 openssl-sys = { version = "0.9", features = ["vendored"]}
 age = { git = "https://github.com/str4d/rage", version = "0.4.0", features = [ "cli-common", "armor" ] }
 bincode = "1.3"
@@ -45,11 +45,11 @@ rpassword = "5.0.0"
 [features]
 default = [ "bw6_asm" ]
 cuda = [ "zexe_algebra/cuda" ]
-bw6_asm = [ "zexe_algebra/bw6_asm" ]
+bw6_asm = [ "zexe_algebra/force_bw6_asm" ]
 
 [patch.'https://github.com/scipr-lab/zexe']
-zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra-core", default-features = false, features = ["derive"] }
-zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
-zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "7c518fd419c3ebed471314473a4752952162262f", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_algebra_core = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra-core", default-features = false, features = ["derive"] }
+zexe_algebra = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "algebra", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_fft = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "ff-fft", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_bench_utils = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "bench-utils", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }
+zexe_r1cs_core = { git = "https://github.com/celo-org/zexe", rev = "02cd4d60a2dbbd5cc69abeea9010610d704f1b34", package = "r1cs-core", default-features = false, features = ["ed_on_bls12_381", "bls12_381", "bls12_377"] }

--- a/src/bin/contribute.rs
+++ b/src/bin/contribute.rs
@@ -86,6 +86,11 @@ pub struct ContributeOpts {
     )]
     pub attestation_path: String,
     #[options(
+        help = "the log path of the Plumo setup",
+        default = "./snark-setup.log"
+    )]
+    pub log_path: String,
+    #[options(
         help = "the storage upload mode",
         default = "auto",
         parse(try_from_str = "upload_mode_from_str")
@@ -247,7 +252,9 @@ impl Contribute {
             Duration::seconds(DELAY_AFTER_ERROR_DURATION_SECS).to_std()?;
         let progress_bar = ProgressBar::new(0);
         let progress_style = ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} {msg}")
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:20.cyan/blue}] {pos}/{len} {wide_msg}",
+            )
             .progress_chars("#>-");
         progress_bar.enable_steady_tick(1000);
         progress_bar.set_style(progress_style);
@@ -397,7 +404,8 @@ impl Contribute {
 
     async fn status_updater(&self, progress_bar: ProgressBar) -> Result<bool> {
         if EXIT_SIGNAL.load(SeqCst) > 0 {
-            progress_bar.set_message("Exit detected, handling chunks in buffer. If there was a problem, please contact the coordinator for help. If you got notified by the coordinator, please destroy the USB drive containing your keys. Press 10 times to force quit.");
+            progress_bar.println("Exit detected, handling chunks in buffer. If there was a problem, please contact the coordinator for help. If you got notified by the coordinator, please destroy the USB drive containing your keys. Press 10 times to force quit.");
+            progress_bar.set_message("");
             progress_bar.set_length(0);
             progress_bar.finish();
             return Ok(true);
@@ -427,9 +435,9 @@ impl Contribute {
             info!("Successfully contributed, thank you for participation! Waiting to see if you're still needed... Don't turn this off! ");
             progress_bar.set_position(num_chunks as u64);
             if !self.exit_when_finished_contributing && !chunk_info.shutdown_signal {
-                progress_bar.set_message("Successfully contributed, thank you for participation! Waiting to see if you're still needed... Don't turn this off!");
+                progress_bar.set_message("Successfully contributed! Don't turn this off yet, you might still be needed. Thank you for participating!");
             } else {
-                progress_bar.set_message("Successfully contributed, thank you for participation! Please destroy the USB drive containing your keys.");
+                progress_bar.set_message("Successfully contributed! Please destroy the USB drive containing your keys. Thank you for participating!");
                 progress_bar.finish();
                 return Ok(true);
             }
@@ -1160,7 +1168,11 @@ async fn main() {
         }
     })
     .expect("Error setting Ctrl-C handler");
-    let appender = tracing_appender::rolling::never(".", "snark-setup.log");
+
+    let opts: ContributeOpts = ContributeOpts::parse_args_default_or_exit();
+    let log_path = std::path::Path::new(&opts.log_path);
+    let appender =
+        tracing_appender::rolling::never(log_path.parent().unwrap(), log_path.file_name().unwrap());
     let (non_blocking, _guard) = tracing_appender::non_blocking(appender);
     tracing_subscriber::fmt()
         .json()
@@ -1168,7 +1180,6 @@ async fn main() {
         .with_writer(non_blocking)
         .init();
 
-    let opts: ContributeOpts = ContributeOpts::parse_args_default_or_exit();
     let (seed, private_key, attestation) = read_keys(&opts.keys_path, opts.unsafe_passphrase, true)
         .expect("Should have loaded Plumo setup keys");
 


### PR DESCRIPTION
We now use the `force_bw6_asm` feature for cross compiling.